### PR TITLE
Update bubble_sort.js

### DIFF
--- a/algorithms/bubble_sort.js
+++ b/algorithms/bubble_sort.js
@@ -9,7 +9,7 @@ function bubbleSort(array) {
       // and the current value is bigger than the next value:
       // the two values need to be swapped (assuming you want the items
       // to be incrementally sorted).
-      if (array[i] && array[i + 1] && array[i] > array[i + 1]) {
+      if (array[i] > array[i + 1]) {
         // Set the current item to the next item, and the next item to the current item.
         [array[i], array[i + 1]] = [array[i + 1], array[i]];
         // Set swapped to true, meaning that the do-while loop will still run.


### PR DESCRIPTION
(arr[i] && arr[i + 1] && arr[i] > arr[i + 1]) fails for value 0, doesn't go in the loop & not sorted. If it's changed to just (arr[i] > arr[i + 1]) it works.
Ex: const arr = [5, 1, 9, 2, -1, 0]. Also a separate logical check can be added for "null", "", undefined check based on what you want to add.